### PR TITLE
Send window title to python activator

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -411,8 +411,8 @@ class DofusOrganizer {
 
     if (nextWindow) {
       console.log(`DofusOrganizer: Activating next window: ${nextWindow.character}`);
-      // Utiliser le WindowActivator au lieu de windowManager.activateWindow
-      this.windowActivator.activateWindow(nextWindow.id);
+      // Send the window title to the WindowActivator
+      this.windowActivator.activateWindow(nextWindow.title);
     }
   }
 
@@ -606,8 +606,11 @@ class DofusOrganizer {
       console.log(`IPC: activate-window called for: ${windowId}`);
 
       try {
-        // MODIFIÉ: Utiliser WindowActivator au lieu de windowManager
-        const result = await this.windowActivator.activateWindow(windowId);
+        const window = this.dofusWindows.find(w => w.id === windowId);
+        const title = window ? window.title : null;
+
+        // Send the title to the WindowActivator
+        const result = await this.windowActivator.activateWindow(title);
 
         // Enhanced activation with immediate feedback
         if (result) {
@@ -668,7 +671,8 @@ class DofusOrganizer {
       // Register the shortcut - MODIFIÉ: utiliser WindowActivator
       return this.shortcutManager.setWindowShortcut(windowId, shortcut, async () => {
         console.log(`ShortcutManager: Executing shortcut for window ${windowId} (dummy)`);
-        await this.windowActivator.activateWindow(windowId);
+        const windowTitle = window.title;
+        await this.windowActivator.activateWindow(windowTitle);
       });
     });
 
@@ -822,7 +826,7 @@ class DofusOrganizer {
         // MODIFIÉ: utiliser WindowActivator
         const success = this.shortcutManager.setWindowShortcut(window.id, existingShortcut, async () => {
           console.log(`ShortcutManager: Executing shortcut for window ${window.id} (dummy)`);
-          await this.windowActivator.activateWindow(window.id);
+          await this.windowActivator.activateWindow(window.title);
         });
 
         if (success) {

--- a/src/script/afficher_fenete.py
+++ b/src/script/afficher_fenete.py
@@ -1,0 +1,31 @@
+import subprocess
+import platform
+import sys
+
+
+def focus_window(title: str) -> bool:
+    """Bring the window with the given title to the foreground."""
+    system = platform.system()
+    try:
+        if system == "Windows":
+            cmd = [
+                "powershell",
+                "-Command",
+                f"(New-Object -ComObject WScript.Shell).AppActivate('{title}')"
+            ]
+            subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        elif system == "Linux":
+            subprocess.run(["wmctrl", "-a", title], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        elif system == "Darwin":
+            subprocess.run(["osascript", "-e", f'tell application \"{title}\" to activate'], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        else:
+            raise RuntimeError(f"Unsupported OS: {system}")
+        return True
+    except Exception as exc:
+        print(f"Error focusing window '{title}': {exc}")
+        return False
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        focus_window(sys.argv[1])

--- a/src/services/WindowActivator.js
+++ b/src/services/WindowActivator.js
@@ -3,9 +3,12 @@
  * Cette fonction sert de placeholder uniforme pour tous les appels de mise au premier plan
  */
 
+const { spawn } = require('child_process');
+const path = require('path');
+
 class WindowActivator {
     constructor() {
-        console.log('WindowActivator: Initialized (no window activation logic)');
+        console.log('WindowActivator: Initialized (using Python script)');
     }
 
     /**
@@ -13,10 +16,12 @@ class WindowActivator {
      * @param {string} windowId - ID de la fenêtre (ignoré)
      * @returns {boolean} - Toujours true pour maintenir la compatibilité
      */
-    bringWindowToFront(windowId = null) {
-        // Fonction volontairement vide (placeholder)
-        console.log(`WindowActivator: bringWindowToFront called${windowId ? ` for ${windowId}` : ''} - no action taken`);
-        return true;
+    bringWindowToFront(windowTitle = null) {
+        if (!windowTitle) {
+            console.log('WindowActivator: bringWindowToFront called with no title');
+            return false;
+        }
+        return this.runPythonScript(windowTitle);
     }
 
     /**
@@ -24,10 +29,12 @@ class WindowActivator {
      * @param {string} windowId - ID de la fenêtre (ignoré)
      * @returns {Promise<boolean>} - Toujours true pour maintenir la compatibilité
      */
-    async activateWindow(windowId) {
-        // Fonction volontairement vide (placeholder)
-        console.log(`WindowActivator: activateWindow called for ${windowId} - no action taken`);
-        return true;
+    async activateWindow(windowTitle) {
+        if (!windowTitle) {
+            console.log('WindowActivator: activateWindow called with no title');
+            return false;
+        }
+        return this.runPythonScript(windowTitle);
     }
 
     /**
@@ -35,10 +42,35 @@ class WindowActivator {
      * @param {string} windowId - ID de la fenêtre (ignoré)
      * @returns {boolean} - Toujours true pour maintenir la compatibilité
      */
-    focusWindow(windowId = null) {
-        // Fonction volontairement vide (placeholder)
-        console.log(`WindowActivator: focusWindow called${windowId ? ` for ${windowId}` : ''} - no action taken`);
-        return true;
+    focusWindow(windowTitle = null) {
+        if (!windowTitle) {
+            console.log('WindowActivator: focusWindow called with no title');
+            return false;
+        }
+        return this.runPythonScript(windowTitle);
+    }
+
+    runPythonScript(title) {
+        return new Promise((resolve) => {
+            const scriptPath = path.join(__dirname, '..', 'script', 'afficher_fenete.py');
+            const proc = spawn('python', [scriptPath, title]);
+
+            let resolved = false;
+            const finish = (code) => {
+                if (!resolved) {
+                    resolved = true;
+                    resolve(code === 0);
+                }
+            };
+
+            proc.on('error', () => {
+                const proc3 = spawn('python3', [scriptPath, title]);
+                proc3.on('close', finish);
+                proc3.on('error', () => finish(1));
+            });
+
+            proc.on('close', finish);
+        });
     }
 
     /**
@@ -66,22 +98,19 @@ class WindowActivator {
 }
 
 // Export des fonctions pour compatibilité
-function bringWindowToFront(windowId = null) {
-    // Fonction volontairement vide (placeholder)
-    console.log(`WindowActivator: Global bringWindowToFront called${windowId ? ` for ${windowId}` : ''} - no action taken`);
-    return true;
+function bringWindowToFront(windowTitle = null) {
+    const activator = new WindowActivator();
+    return activator.bringWindowToFront(windowTitle);
 }
 
-function activateWindow(windowId) {
-    // Fonction volontairement vide (placeholder)
-    console.log(`WindowActivator: Global activateWindow called for ${windowId} - no action taken`);
-    return Promise.resolve(true);
+function activateWindow(windowTitle) {
+    const activator = new WindowActivator();
+    return activator.activateWindow(windowTitle);
 }
 
-function focusWindow(windowId = null) {
-    // Fonction volontairement vide (placeholder)
-    console.log(`WindowActivator: Global focusWindow called${windowId ? ` for ${windowId}` : ''} - no action taken`);
-    return true;
+function focusWindow(windowTitle = null) {
+    const activator = new WindowActivator();
+    return activator.focusWindow(windowTitle);
 }
 
 module.exports = WindowActivator;

--- a/src/services/WindowManagerWindows.js
+++ b/src/services/WindowManagerWindows.js
@@ -617,8 +617,11 @@ try {
         return false;
       }
 
-      // MODIFIÉ: Utiliser WindowActivator au lieu de la logique PowerShell
-      const result = await this.windowActivator.activateWindow(windowId);
+      const windowInfo = this.windows.get(windowId);
+      const title = windowInfo ? windowInfo.info.title : null;
+
+      // Utiliser le WindowActivator avec le titre de la fenêtre
+      const result = await this.windowActivator.activateWindow(title);
 
       if (result) {
         // Update active state immediately
@@ -678,7 +681,7 @@ try {
       for (let i = 0; i < enabledWindows.length; i++) {
         const windowData = enabledWindows[i];
         console.log(`WindowManagerWindows: Organizing window ${i + 1}/${enabledWindows.length}: ${windowData.info.character} (dummy)`);
-        await this.windowActivator.activateWindow(windowData.info.id);
+        await this.windowActivator.activateWindow(windowData.info.title);
       }
 
       return true;


### PR DESCRIPTION
## Summary
- add simple Python function to focus a window by title
- update `WindowActivator` to run the new Python script
- send window titles instead of IDs when activating windows

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_684eb2a9cf00832281fa0dfe04bb9292