### PR TITLE
Fix Python script path for packaged builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,13 @@
         "filter": [
           "**/*"
         ]
+      },
+      {
+        "from": "src/script/",
+        "to": "script/",
+        "filter": [
+          "**/*"
+        ]
       }
     ],
     "win": {

--- a/src/main.js
+++ b/src/main.js
@@ -208,7 +208,9 @@ class DofusOrganizer {
     console.log('DofusOrganizer: Launching Python interface...');
 
     try {
-      const pythonScript = path.join(__dirname, '..', 'script', 'afficher_fenetre.py');
+      const pythonScript = app.isPackaged
+        ? path.join(process.resourcesPath, 'script', 'afficher_fenetre.py')
+        : path.join(__dirname, '..', 'script', 'afficher_fenetre.py');
 
       // Lancer le script Python en mode détaché
       const pythonProcess = spawn('python', [pythonScript], {

--- a/src/services/WindowActivator.js
+++ b/src/services/WindowActivator.js
@@ -5,10 +5,14 @@
 
 const { spawn } = require('child_process');
 const path = require('path');
+const { app } = require('electron');
 
 class WindowActivator {
     constructor() {
         console.log('WindowActivator: Initialized (using Python script)');
+        this.scriptPath = app.isPackaged
+            ? path.join(process.resourcesPath, 'script', 'afficher_fenetre.py')
+            : path.join(__dirname, '..', 'script', 'afficher_fenetre.py');
     }
 
     /**
@@ -52,7 +56,7 @@ class WindowActivator {
 
     runPythonScript(title) {
         return new Promise((resolve) => {
-            const scriptPath = path.join(__dirname, '..', 'script', 'afficher_fenetre.py');
+            const scriptPath = this.scriptPath;
             const proc = spawn('python', [scriptPath, title]);
 
             let resolved = false;


### PR DESCRIPTION
## Summary
- ensure Python script is available in packaged apps
- resolve Python script path using `app.isPackaged`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_684eccf0dfc083228ed1bf04c95a7415